### PR TITLE
Update Shroomite visor into vanity helmet

### DIFF
--- a/Content/Items/Armor/Ranged/Hardmode/Pieces/ShroomiteDartHelmet.cs
+++ b/Content/Items/Armor/Ranged/Hardmode/Pieces/ShroomiteDartHelmet.cs
@@ -19,32 +19,6 @@ namespace Polarities.Content.Items.Armor.Ranged.Hardmode.Pieces
             Item.CloneDefaults(ItemID.ShroomiteHelmet);
             Item.headSlot = EquipLoader.GetEquipSlot(Mod, Name, EquipType.Head);
         }
-
-        public override void UpdateEquip(Player player)
-        {
-            player.GetCritChance(DamageClass.Ranged) += 5f;
-            player.GetModPlayer<PolaritiesPlayer>().dartDamage += 0.15f;
-        }
-
-        public override bool IsArmorSet(Item head, Item body, Item legs)
-        {
-            return body.type == ItemID.ShroomiteBreastplate && legs.type == ItemID.ShroomiteLeggings;
-        }
-
-        public override void UpdateArmorSet(Player player)
-        {
-            player.setBonus = Language.GetTextValue("ArmorSetBonus.Shroomite");
-            player.shroomiteStealth = true;
-        }
-
-        public override void AddRecipes()
-        {
-            CreateRecipe()
-                .AddIngredient(ItemID.ShroomiteBar, 12)
-                .AddTile(TileID.MythrilAnvil)
-                .SortAfterFirstRecipesOf(ItemID.ShroomiteHelmet)
-                .Register();
-        }
     }
 }
 

--- a/Content/Items/Armor/Ranged/Hardmode/Pieces/ShroomiteDartHelmet.cs
+++ b/Content/Items/Armor/Ranged/Hardmode/Pieces/ShroomiteDartHelmet.cs
@@ -3,6 +3,7 @@ using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader;
 using Polarities.Core;
+using static Terraria.ModLoader.ModContent;
 
 namespace Polarities.Content.Items.Armor.Ranged.Hardmode.Pieces
 {
@@ -18,6 +19,34 @@ namespace Polarities.Content.Items.Armor.Ranged.Hardmode.Pieces
         {
             Item.CloneDefaults(ItemID.ShroomiteHelmet);
             Item.headSlot = EquipLoader.GetEquipSlot(Mod, Name, EquipType.Head);
+        }
+    }
+
+    public partial class TruffleShroomiteSell : GlobalNPC
+    {
+        public override bool InstancePerEntity => true;
+
+        public override void ModifyActiveShop(NPC npc, string shopName, Item[] items)
+        {
+            if (npc.type == NPCID.Truffle &&
+                (ModUtils.Contains(Main.LocalPlayer.inventory, ItemID.ShroomiteHeadgear
+              || ModUtils.Contains(Main.LocalPlayer.inventory, ItemID.ShroomiteMask
+              || ModUtils.Contains(Main.LocalPlayer.inventory, ItemID.ShroomiteHelmet
+              || ModUtils.Contains(Main.LocalPlayer.armor, ItemID.ShroomiteHeadgear
+              || ModUtils.Contains(Main.LocalPlayer.armor, ItemID.ShroomiteMask
+              || ModUtils.Contains(Main.LocalPlayer.armor, ItemID.ShroomiteHelmet))
+            {
+                int firstFreeIndex = items.Length - 1;
+                for (int i = items.Length - 1; i > -1; i--)
+                {
+                    if (items[i] != null)
+                    {
+                        firstFreeIndex = i + 1;
+                        break;
+                    }
+                }
+                if (firstFreeIndex < items.Length) items[firstFreeIndex] = new Item(ItemType<ShroomiteDartHelmet>());
+            }
         }
     }
 }


### PR DESCRIPTION
- Shroomite Visor is now a vanity helmet
- Crafting recipe removed
- Sold by Truffle when a different Shroomite helmet is equipped or held in the inventory